### PR TITLE
Allow firebase ^5.0.0 as peerDependency

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,9 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
-var _uuid = require('uuid');
+var _v = require('uuid/v4');
+
+var _v2 = _interopRequireDefault(_v);
 
 var _image = require('./utils/image');
 
@@ -32,12 +34,16 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 */
 
 var generateRandomFilename = function generateRandomFilename() {
-  return (0, _uuid.v4)();
+  return (0, _v2.default)();
 };
 
 function extractExtension(filename) {
-  return (/(?:\.([^.]+))?$/.exec(filename)[0]
-  );
+  var ext = /(?:\.([^.]+))?$/.exec(filename);
+  if (ext != null && ext[0] != null) {
+    return ext[0];
+  } else {
+    return '';
+  }
 }
 
 var FirebaseFileUploader = function (_Component) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-firebase-file-uploader",
-  "version": "2.4.1",
+  "version": "2.4.3",
   "description": "A file uploader for react that uploads files to your firebase storage",
   "main": "lib/index.js",
   "scripts": {
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/sprmn/react-firebase-file-uploader#readme",
   "peerDependencies": {
-    "firebase": "^3.5.2 || ^4.0.0",
+    "firebase": "^3.5.2 || ^4.0.0 || ^5.0.0",
     "react": "^15.3.2 || ^16.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -648,9 +648,10 @@ babel-preset-flow@^6.23.0:
   dependencies:
     babel-plugin-transform-flow-strip-types "^6.22.0"
 
-babel-preset-react@^6.16.0:
+babel-preset-react@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-preset-react/-/babel-preset-react-6.24.1.tgz#ba69dfaea45fc3ec639b6a4ecea6e17702c91380"
+  integrity sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=
   dependencies:
     babel-plugin-syntax-jsx "^6.3.13"
     babel-plugin-transform-react-display-name "^6.23.0"
@@ -1777,13 +1778,14 @@ util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
-uuid@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
-
 uuid@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
+
+uuid@^3.2.1:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
 v8flags@^2.0.10:
   version "2.1.1"


### PR DESCRIPTION
Version to 2.4.3 - not a breaking change, a patch release after the latest npm version.

Changes in lib - only because the last commit was not build I guess...

I have not extensively verified that firebase 5.x causes no problems - I have read the breaking changes and none of them seem to apply, I have also been using react-firebase-file-uploader with 5.x (as far as 5.8.4) for some time now.