### PR TITLE
HTML input file selection event not firing upon selecting the same file

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -176,6 +176,9 @@ var FirebaseFileUploader = function (_Component) {
 
       return _react2.default.createElement(Input, _extends({
         type: 'file',
+        onClick: function onClick(e) {
+          e.target.value = null;
+        },
         onChange: this.handleFileSelection
       }, props, {
         style: inputStyle

--- a/src/index.js
+++ b/src/index.js
@@ -178,6 +178,7 @@ export default class FirebaseFileUploader extends Component<Props> {
     return (
       <Input
         type="file"
+        onClick={ e => { e.target.value = null } } 
         onChange={this.handleFileSelection}
         {...props}
         style={inputStyle}


### PR DESCRIPTION
This is not something related with React or your component, it is just something related with HTML <input type="file">
ref https://stackoverflow.com/questions/12030686/html-input-file-selection-event-not-firing-upon-selecting-the-same-file

Actually it was very annoying particularly when something fails and you try to upload the same file.
Now if you select the same file the upload process starts again.


PS: are you still maintaining this repo? It is seems abandoned in the last 3-6 months.