### PR TITLE
Old reference of onProgress & onUploadSuccess are called 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -76,9 +76,6 @@ export default class FirebaseFileUploader extends Component<Props> {
   startUpload(file: File) {
     const {
       onUploadStart,
-      onProgress,
-      onUploadError,
-      onUploadSuccess,
       storageRef,
       metadata,
       randomizeFilename,
@@ -122,17 +119,17 @@ export default class FirebaseFileUploader extends Component<Props> {
         task.on(
           'state_changed',
           snapshot =>
-            onProgress &&
-            onProgress(
+            this.props.onProgress &&
+            this.props.onProgress(
               Math.round(100 * snapshot.bytesTransferred / snapshot.totalBytes),
               task
             ),
-          error => onUploadError && onUploadError(error, task),
+          error => this.props.onUploadError && this.props.onUploadError(error, task),
           () => {
             this.removeTask(task);
             return (
-              onUploadSuccess &&
-              onUploadSuccess(task.snapshot.metadata.name, task)
+              this.props.onUploadSuccess &&
+              this.props.onUploadSuccess(task.snapshot.metadata.name, task)
             );
           }
         );


### PR DESCRIPTION
When used within a functionnal component, onProgress and on OnUploadSuccess are called with old reference of the functions.

For example : 

```
const MyComponent = () => {
    const [ currentFileProgress, setCurrentFileProgress ] = useState(0);

    return (
        <FileUploader
            accept="*/*"
            storageRef={myStorageRef}
            onUploadStart={() => {}}
            onUploadError={() => {}}
            onUploadSuccess={() => {
                console.log("currentFileProgress", currentFileProgress);
                // THIS WILL DISPLAY '0'
            }}
            onProgress={progress => setCurrentFileProgress(progress)}
        />
    )
}
```

This is because onUploadSuccess and onProgress are being called inside the callback of a firebase task

The task is running, so if the component has new props, onUploadSuccess and onProgress wont be updated 