### PR TITLE
Firebase 8 support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -147,7 +147,7 @@ var FirebaseFileUploader = function (_Component) {
           return onUploadError && onUploadError(error, task);
         }, function () {
           _this2.removeTask(task);
-          return onUploadSuccess && onUploadSuccess(task.snapshot.metadata.name, task);
+          return onUploadSuccess && onUploadSuccess(filenameToUse, task);
         });
         _this2.uploadTasks.push(task);
       });

--- a/src/index.js
+++ b/src/index.js
@@ -129,7 +129,7 @@ export default class FirebaseFileUploader extends Component<Props> {
             this.removeTask(task);
             return (
               this.props.onUploadSuccess &&
-              this.props.onUploadSuccess(task.snapshot.metadata.name, task)
+              this.props.onUploadSuccess(filenameToUse, task)
             );
           }
         );


### PR DESCRIPTION
https://github.com/fris-fruitig/react-firebase-file-uploader/issues/50

I don't fully understand why it was getting the filename from metadata before. Seems like we already know the filename at this point. 

If metadata is needed, I think it has to call getMetadata() first
https://firebase.google.com/docs/storage/web/file-metadata#get_file_metadata