### PR TITLE
Fixed error getting name from metadata after upload

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -146,8 +146,11 @@ var FirebaseFileUploader = function (_Component) {
         }, function (error) {
           return onUploadError && onUploadError(error, task);
         }, function () {
+          var name = storageRef.child(filenameToUse).getMetadata().then(function (metadata) {
+            return metadata.name;
+          });
           _this2.removeTask(task);
-          return onUploadSuccess && onUploadSuccess(task.snapshot.metadata.name, task);
+          return onUploadSuccess && onUploadSuccess(name, task);
         });
         _this2.uploadTasks.push(task);
       });


### PR DESCRIPTION
var name = storageRef.child(filenameToUse).getMetadata().then(function (metadata) {
            return metadata.name;
          });